### PR TITLE
Little fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ and enter the following into your terminal:
 ```
 git clone --recursive https://github.com/andresgongora/synth-shell.git
 chmod +x synth-shell/setup.sh
-synth-shell/setup.sh
+cd synth-shell
+./setup.sh
 ```
 
 Note that for `fancy-bash-prompt.sh` you might also need


### PR DESCRIPTION
Previously by running the commands in the automatic setup users got the
following error message:
```
user_io.sh: line 31: cd: /home/kunfu/Workspace/bash-tools/bash-tools: No such file or directory
Include failed /home/kunfu/Workspace->bash-tools/bash-tools/shell.sh
```