### PR TITLE
Update better-ls.sh

### DIFF
--- a/synth-shell/better-ls.sh
+++ b/synth-shell/better-ls.sh
@@ -74,7 +74,7 @@
 function better_ls()
 {
 	shopt -s extglob
-	local LS="$(which ls)"
+	local LS="$(which --skip-alias ls)"
 
 
 	## IF NO ARGUMENTS PASSED -> run better ls version on current folder


### PR DESCRIPTION
On my system (Fedora 35), I was getting a lot of errors because the result of "which ls" was returning the alias value. Adding the --skip-alias bypasses any aliases and just returns the actual binary path as expected.