### PR TITLE
rectified install at line 145: from instal to install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cd synth-shell
 ```
 
 Note that for `fancy-bash-prompt.sh` you might also need
-[power-line fonts](https://github.com/powerline/fonts). You can instal it
+[power-line fonts](https://github.com/powerline/fonts). You can install it
 as follows (the exact name of the package varies from distro to distro):
 
 * ArchLinux: `sudo pacman -S powerline-fonts`


### PR DESCRIPTION
While reading the readme.md for installation I found a typo (on line 145)  in the readme file. And I rectified it.